### PR TITLE
Pin @types/electron to block breaking change in update

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@types/chai-datetime": "0.0.30",
     "@types/classnames": "^0.0.32",
     "@types/codemirror": "0.0.38",
-    "@types/electron": "^1.4.36",
+    "@types/electron": "1.4.38",
     "@types/electron-window-state": "^2.0.28",
     "@types/event-kit": "^1.2.28",
     "@types/fs-extra": "2.1.0",


### PR DESCRIPTION
An update to `@types/electron` - 1.6.10 - from yesterday is being pulled in, will affect `npm install` due to our linting step:

```
> @ compile:tslint C:\projects\gitburn
> tsc -p tslint-rules
node_modules/@types/electron-window-state/index.d.ts(6,1): error TS2688: Cannot find type definition file for 'electron'.
node_modules/@types/electron-window-state/index.d.ts(52,15): error TS2503: Cannot find namespace 'Electron'.
node_modules/@types/electron-window-state/index.d.ts(57,18): error TS2503: Cannot find namespace 'Electron'.
```